### PR TITLE
test: harden release upgrade cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to AI SkillHub are documented here.
 
 ### Verification
 
-- Frontend production build and 58 behavior contracts pass.
+- Frontend production build and 59 behavior contracts pass.
 - Rust: 140 library tests, 12 Codex doctor tests, and 8 MCP tests pass; five
   explicit network gates and one formal-artifact gate remain ignored by design.
 - PowerShell 5.1 and 7 isolated sync tests cover two consecutive empty syncs,

--- a/app-next/scripts/formal-release-builder-contract.test.mjs
+++ b/app-next/scripts/formal-release-builder-contract.test.mjs
@@ -11,6 +11,7 @@ const tauriConfig = JSON.parse(read(appRoot, "src-tauri", "tauri.conf.json"));
 const version = packageJson.version;
 const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const builder = read(appRoot, "scripts", "build-formal-release.ps1");
+const nsisQa = read(appRoot, "scripts", "test-nsis-install-upgrade.ps1");
 
 test("formal release version surfaces agree before signing", () => {
   assert.equal(tauriConfig.version, version);
@@ -54,4 +55,19 @@ test("future fallback manifest is opt-in after public verification", () => {
   assert.match(builder, /Fallback updater manifest unchanged; publish it only after the public release assets pass verification/);
   const unconditionalWrites = [...builder.matchAll(/WriteAllText\(\s*\$FallbackLatestJsonPath/g)];
   assert.equal(unconditionalWrites.length, 1, "fallback manifest should have only the guarded write site");
+});
+
+test("NSIS QA retries only its bounded TEMP sandbox cleanup", () => {
+  assert.match(nsisQa, /function Remove-QaSandboxWithRetry/);
+  assert.match(nsisQa, /function Assert-ExactQaRoot/);
+  assert.match(nsisQa, /QA cleanup target is not this run's exact GUID sandbox/);
+  assert.match(nsisQa, /QA cleanup refuses a reparse-point root/);
+  assert.match(nsisQa, /\[DateTime\]::UtcNow\.AddSeconds\(\$TimeoutSeconds\)/);
+  assert.match(nsisQa, /Bounded QA sandbox cleanup/);
+  assert.match(nsisQa, /function Invoke-BoundedSqlite/);
+  assert.doesNotMatch(nsisQa, /& \$sqlite\.Source/);
+  assert.match(nsisQa, /Remove-QaSandboxWithRetry -Path \$QaRoot/);
+  assert.match(nsisQa, /if \(\$registryRestoreFailed\)/);
+  assert.match(nsisQa, /Registry recovery evidence preserved/);
+  assert.match(nsisQa, /recovery files preserved at \$QaRoot/);
 });

--- a/app-next/scripts/test-nsis-install-upgrade.ps1
+++ b/app-next/scripts/test-nsis-install-upgrade.ps1
@@ -43,6 +43,24 @@ function Assert-PathInsideTemp([string]$Path) {
   }
 }
 
+function Assert-ExactQaRoot([string]$Path) {
+  Assert-PathInsideTemp $Path
+  $full = [IO.Path]::GetFullPath($Path).TrimEnd('\')
+  $expected = [IO.Path]::GetFullPath($script:QaRoot).TrimEnd('\')
+  $expectedLeaf = "AI-SkillHub-Installer-QA-$script:QaId"
+  if (-not $full.Equals($expected, [StringComparison]::OrdinalIgnoreCase) -or
+      (Split-Path -Leaf $full) -cne $expectedLeaf) {
+    throw "QA cleanup target is not this run's exact GUID sandbox: $full"
+  }
+  if (Test-Path -LiteralPath $full) {
+    $item = Get-Item -LiteralPath $full -Force
+    if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+      throw "QA cleanup refuses a reparse-point root: $full"
+    }
+  }
+  return $full
+}
+
 function ConvertTo-NativeRegistryPath([string]$Path) {
   if ($Path.StartsWith('HKCU:\', [StringComparison]::OrdinalIgnoreCase)) {
     return 'HKCU\' + $Path.Substring(6)
@@ -70,8 +88,12 @@ function New-RegistrySnapshot {
 
   $reg = Get-Command reg.exe -ErrorAction Stop
   $nativePath = ConvertTo-NativeRegistryPath $Path
-  & $reg.Source export $nativePath $BackupFile /y | Out-Null
-  if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $BackupFile -PathType Leaf)) {
+  $exitCode = Invoke-BoundedProcess `
+    -FilePath $reg.Source `
+    -ArgumentList @('export', $nativePath, $BackupFile, '/y') `
+    -Label "Registry export $nativePath" `
+    -TimeoutSeconds 30
+  if ($exitCode -ne 0 -or -not (Test-Path -LiteralPath $BackupFile -PathType Leaf)) {
     throw "Could not back up registry key: $nativePath"
   }
   return $snapshot
@@ -83,8 +105,17 @@ function Restore-RegistrySnapshot {
     [psobject]$Snapshot
   )
 
+  $reg = Get-Command reg.exe -ErrorAction Stop
+  $nativePath = ConvertTo-NativeRegistryPath $Snapshot.Path
   if (Test-Path -LiteralPath $Snapshot.Path) {
-    Remove-Item -LiteralPath $Snapshot.Path -Recurse -Force
+    $deleteExit = Invoke-BoundedProcess `
+      -FilePath $reg.Source `
+      -ArgumentList @('delete', $nativePath, '/f') `
+      -Label "Registry reset $nativePath" `
+      -TimeoutSeconds 30
+    if ($deleteExit -ne 0) {
+      throw "Could not reset registry key before restore: $nativePath"
+    }
   }
   if (-not $Snapshot.Existed) {
     return
@@ -93,11 +124,21 @@ function Restore-RegistrySnapshot {
     throw "Registry snapshot is missing: $($Snapshot.BackupFile)"
   }
 
-  $reg = Get-Command reg.exe -ErrorAction Stop
-  & $reg.Source import $Snapshot.BackupFile | Out-Null
-  if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $Snapshot.Path)) {
+  $importExit = Invoke-BoundedProcess `
+    -FilePath $reg.Source `
+    -ArgumentList @('import', $Snapshot.BackupFile) `
+    -Label "Registry restore $nativePath" `
+    -TimeoutSeconds 30
+  if ($importExit -ne 0 -or -not (Test-Path -LiteralPath $Snapshot.Path)) {
     throw "Could not restore registry key: $($Snapshot.Path)"
   }
+}
+
+function ConvertTo-ProcessArgument([string]$Value) {
+  if ($Value -notmatch '[\s"]') {
+    return $Value
+  }
+  return '"' + $Value.Replace('"', '\"') + '"'
 }
 
 function Stop-TestProcess {
@@ -129,7 +170,8 @@ function Invoke-BoundedProcess {
     [int]$TimeoutSeconds
   )
 
-  $process = Start-Process -FilePath $FilePath -ArgumentList $ArgumentList `
+  $safeArguments = @($ArgumentList | ForEach-Object { ConvertTo-ProcessArgument ([string]$_) })
+  $process = Start-Process -FilePath $FilePath -ArgumentList $safeArguments `
     -PassThru -WindowStyle Hidden
   if ($null -eq $process) {
     throw "$Label could not be started."
@@ -143,6 +185,105 @@ function Invoke-BoundedProcess {
   } finally {
     $process.Dispose()
   }
+}
+
+function Invoke-BoundedSqlite {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$FilePath,
+    [Parameter(Mandatory = $true)]
+    [string]$DatabasePath,
+    [Parameter(Mandatory = $true)]
+    [string]$Sql,
+    [Parameter(Mandatory = $true)]
+    [string]$Label,
+    [ValidateRange(1, 120)]
+    [int]$TimeoutSeconds = 30
+  )
+
+  $psi = New-Object Diagnostics.ProcessStartInfo
+  $psi.FileName = $FilePath
+  $psi.Arguments = ConvertTo-ProcessArgument $DatabasePath
+  $psi.UseShellExecute = $false
+  $psi.CreateNoWindow = $true
+  $psi.RedirectStandardInput = $true
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+  $process = [Diagnostics.Process]::Start($psi)
+  if ($null -eq $process) {
+    throw "$Label could not be started."
+  }
+  try {
+    $process.StandardInput.WriteLine($Sql)
+    $process.StandardInput.Close()
+    if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+      Stop-TestProcess -Process $process -Label $Label
+      throw "$Label timed out after $TimeoutSeconds seconds."
+    }
+    $stdout = $process.StandardOutput.ReadToEnd()
+    $stderr = $process.StandardError.ReadToEnd()
+    return [pscustomobject]@{
+      ExitCode = [int]$process.ExitCode
+      StdOut = [string]$stdout
+      StdErr = [string]$stderr
+    }
+  } finally {
+    $process.Dispose()
+  }
+}
+
+function Remove-QaSandboxWithRetry {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [ValidateRange(1, 60)]
+    [int]$TimeoutSeconds = 20
+  )
+
+  $exactPath = Assert-ExactQaRoot $Path
+  $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+  $lastError = $null
+  do {
+    try {
+      $exactPath = Assert-ExactQaRoot $exactPath
+      if (-not (Test-Path -LiteralPath $exactPath)) {
+        return
+      }
+      $escapedPath = $exactPath.Replace("'", "''")
+      $cleanupCommand = @"
+`$ErrorActionPreference = 'Stop'
+try {
+  `$target = '$escapedPath'
+  `$item = Get-Item -LiteralPath `$target -Force
+  if ((`$item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { exit 3 }
+  Remove-Item -LiteralPath `$target -Recurse -Force -ErrorAction Stop
+  exit 0
+} catch { exit 2 }
+"@
+      $encodedCommand = [Convert]::ToBase64String(
+        [Text.Encoding]::Unicode.GetBytes($cleanupCommand)
+      )
+      $powershell = Get-Command powershell.exe -ErrorAction Stop
+      $remainingSeconds = [Math]::Max(
+        1,
+        [Math]::Min(3, [Math]::Ceiling(($deadline - [DateTime]::UtcNow).TotalSeconds))
+      )
+      $exitCode = Invoke-BoundedProcess `
+        -FilePath $powershell.Source `
+        -ArgumentList @('-NoProfile', '-NonInteractive', '-EncodedCommand', $encodedCommand) `
+        -Label 'Bounded QA sandbox cleanup' `
+        -TimeoutSeconds ([int]$remainingSeconds)
+      if ($exitCode -eq 0 -and -not (Test-Path -LiteralPath $exactPath)) {
+        return
+      }
+      $lastError = "cleanup process exited $exitCode"
+    } catch {
+      $lastError = $_.Exception.Message
+    }
+    Start-Sleep -Milliseconds 400
+  } while ([DateTime]::UtcNow -lt $deadline)
+
+  throw "QA sandbox remained busy for $TimeoutSeconds seconds: $lastError"
 }
 
 function Test-AppStartup {
@@ -206,6 +347,7 @@ foreach ($path in @($QaRoot, $InstallRoot, $DataRoot, $RegistryBackupRoot)) {
 $ProductKeySnapshot = $null
 $UninstallKeySnapshot = $null
 $testFailure = $null
+$registryRestoreFailed = $false
 $cleanupFailures = New-Object 'System.Collections.Generic.List[string]'
 
 try {
@@ -264,7 +406,7 @@ try {
     $sqlite = Get-Command sqlite3 -ErrorAction SilentlyContinue
     if (-not $sqlite) { throw 'sqlite3 is required for the cross-version data gate.' }
     $stamp = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds().ToString()
-    & $sqlite.Source $database @"
+    $seedSql = @"
 INSERT OR REPLACE INTO sources (
   id, name, source_type, url, local_path, install_mode,
   category_id, note, enabled, created_at, updated_at
@@ -279,7 +421,14 @@ INSERT OR REPLACE INTO source_overrides (
   'qa-upgrade-source', '', '', '', 'upgrade sentinel', NULL, 5, '$stamp'
 );
 "@
-    if ($LASTEXITCODE -ne 0) { throw 'Could not seed previous-version user data.' }
+    $seedResult = Invoke-BoundedSqlite `
+      -FilePath $sqlite.Source `
+      -DatabasePath $database `
+      -Sql $seedSql `
+      -Label 'Seed previous-version SQLite data'
+    if ($seedResult.ExitCode -ne 0) {
+      throw "Could not seed previous-version user data: $($seedResult.StdErr.Trim())"
+    }
   }
 
   $sentinel = Join-Path $DataRoot 'update-preserves-user-data.txt'
@@ -312,10 +461,15 @@ INSERT OR REPLACE INTO source_overrides (
   if (-not [string]::IsNullOrWhiteSpace($PreviousInstallerPath) -and $databaseCreated) {
     $sqlite = Get-Command sqlite3 -ErrorAction SilentlyContinue
     if (-not $sqlite) { throw 'sqlite3 is required for the cross-version data gate.' }
-    $preservedParentRating = [int](
-      & $sqlite.Source $database `
-        "SELECT rating FROM source_overrides WHERE source_id='qa-upgrade-source';"
-    )
+    $ratingResult = Invoke-BoundedSqlite `
+      -FilePath $sqlite.Source `
+      -DatabasePath $database `
+      -Sql "SELECT rating FROM source_overrides WHERE source_id='qa-upgrade-source';" `
+      -Label 'Read preserved parent rating'
+    if ($ratingResult.ExitCode -ne 0) {
+      throw "Could not read preserved parent rating: $($ratingResult.StdErr.Trim())"
+    }
+    $preservedParentRating = [int]$ratingResult.StdOut.Trim()
   }
 
   $result = [pscustomobject]@{
@@ -374,14 +528,18 @@ INSERT OR REPLACE INTO source_overrides (
     try {
       Restore-RegistrySnapshot -Snapshot $snapshot
     } catch {
-      $cleanupFailures.Add($_.Exception.Message)
+      $registryRestoreFailed = $true
+      $cleanupFailures.Add(
+        "Registry restore failed for $($snapshot.Path); recovery files preserved at $QaRoot`: $($_.Exception.Message)"
+      )
     }
   }
 
   try {
-    if (-not $KeepSandbox -and (Test-Path -LiteralPath $QaRoot)) {
-      Assert-PathInsideTemp $QaRoot
-      Remove-Item -LiteralPath $QaRoot -Recurse -Force
+    if ($registryRestoreFailed) {
+      Write-Warning "Registry recovery evidence preserved: $QaRoot"
+    } elseif (-not $KeepSandbox -and (Test-Path -LiteralPath $QaRoot)) {
+      Remove-QaSandboxWithRetry -Path $QaRoot
       Write-Host "Installer QA sandbox removed: $QaRoot"
     }
   } catch {


### PR DESCRIPTION
## What changed

- retries transient NSIS/WebView2 sandbox cleanup with bounded child processes
- restricts recursive cleanup to the exact per-run GUID directory under TEMP and rejects reparse roots
- preserves registry backup files whenever either HKCU restore fails
- bounds reg.exe and sqlite3 helpers and terminates them on timeout
- adds release contract coverage and updates the behavior-contract count

## Why

The second real 3.1.10 to 3.1.11 upgrade simulation passed every product assertion but transiently held the QA installation directory open. The original immediate cleanup failed, and a deeper audit found that a registry-restore failure could then lose its own recovery files.

## Validation

- Windows PowerShell 5.1 and PowerShell 7 parse
- formal release contract 5/5
- all frontend/release contracts 59/59
- two real 3.1.10 to 3.1.11 NSIS upgrade runs passed and restored/removed their unique sandboxes
- independent read-only review found no remaining P0/P1
