### PR TITLE
test: stabilize v3.2.1 formal desktop QA

### DIFF
--- a/app-next/scripts/formal-release-builder-contract.test.mjs
+++ b/app-next/scripts/formal-release-builder-contract.test.mjs
@@ -86,5 +86,11 @@ test("formal desktop QA isolates host roots and waits for an app-side startup pa
   assert.match(formalDesktopQa, /Set-ProcessEnvironment 'CLAUDE_CONFIG_DIR' \(Join-Path \$qaProfileRoot '\.claude'\)/);
   assert.match(formalDesktopQa, /Set-ProcessEnvironment 'AI_SKILLHUB_ROOT' \$qaProjectRoot/);
   assert.match(formalDesktopQa, /Copy-Item -LiteralPath \(Join-Path \$appNextRoot "runtime\\\$runtimeFile"\)/);
+  assert.match(formalDesktopQa, /Formal QA app did not expose a verifiable executable path/);
+  assert.match(formalDesktopQa, /Cannot verify the isolated QA process path before stopping it/);
   assert.match(startupCacheQa, /value === "unknown" \? false : value/);
+  assert.ok(
+    startupCacheQa.indexOf("const indexed") < startupCacheQa.indexOf("const startupLoadPath"),
+    "startup path must be read after the indexed snapshot has completed",
+  );
 });

--- a/app-next/scripts/v3.2.0-formal-desktop-qa.ps1
+++ b/app-next/scripts/v3.2.0-formal-desktop-qa.ps1
@@ -118,7 +118,20 @@ function Start-VerifiedQaApp([bool]$ExpectCached, [string]$RunLabel) {
     $process = Start-Process -FilePath $resolvedExecutable -WindowStyle Hidden -PassThru
     Set-ProcessEnvironment 'AI_SKILLHUB_EXPECTED_PID' $process.Id.ToString()
 
-    $actualPath = [IO.Path]::GetFullPath((Get-Process -Id $process.Id -ErrorAction Stop).Path)
+    $rawPath = ''
+    for ($attempt = 0; $attempt -lt 40; $attempt += 1) {
+      $startedProcess = Get-Process -Id $process.Id -ErrorAction Stop
+      if ($startedProcess.HasExited) {
+        throw "Formal QA app exited before its executable path could be verified: $($startedProcess.ExitCode)"
+      }
+      $rawPath = [string]$startedProcess.Path
+      if (-not [string]::IsNullOrWhiteSpace($rawPath)) { break }
+      Start-Sleep -Milliseconds 100
+    }
+    if ([string]::IsNullOrWhiteSpace($rawPath)) {
+      throw 'Formal QA app did not expose a verifiable executable path.'
+    }
+    $actualPath = [IO.Path]::GetFullPath($rawPath)
     if (-not [string]::Equals($actualPath, $resolvedExecutable, [StringComparison]::OrdinalIgnoreCase)) {
       throw "Started process path does not match the formal executable: $actualPath"
     }
@@ -158,12 +171,20 @@ function Stop-VerifiedQaApp($App) {
   if (-not $App) { return }
   $process = Get-Process -Id $App.Process.Id -ErrorAction SilentlyContinue
   if ($process) {
-    $actualPath = [IO.Path]::GetFullPath($process.Path)
-    if (-not [string]::Equals($actualPath, $resolvedExecutable, [StringComparison]::OrdinalIgnoreCase)) {
-      throw "Refusing to stop an unexpected process: $actualPath"
+    if ($process.HasExited) {
+      $process = $null
+    } else {
+      $rawPath = [string]$process.Path
+      if ([string]::IsNullOrWhiteSpace($rawPath)) {
+        throw "Cannot verify the isolated QA process path before stopping it."
+      }
+      $actualPath = [IO.Path]::GetFullPath($rawPath)
+      if (-not [string]::Equals($actualPath, $resolvedExecutable, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to stop an unexpected process: $actualPath"
+      }
+      Stop-Process -Id $process.Id -Force
+      $process.WaitForExit(10000) | Out-Null
     }
-    Stop-Process -Id $process.Id -Force
-    $process.WaitForExit(10000) | Out-Null
   }
   for ($attempt = 0; $attempt -lt 40; $attempt += 1) {
     if (-not (Get-NetTCPConnection -LocalPort $App.Port -State Listen -ErrorAction SilentlyContinue)) { return }

--- a/app-next/scripts/v3.2.0-startup-cache-qa.cjs
+++ b/app-next/scripts/v3.2.0-startup-cache-qa.cjs
@@ -70,15 +70,6 @@ const identity = buildIdentity();
     const page = await waitForAppPage(browser);
 
     await page.locator(".shell").waitFor({ timeout: 30_000 });
-    const startupLoadPath = await page.waitForFunction(async () => {
-      const value = await window.__TAURI_INTERNALS__.invoke("get_startup_load_path");
-      return value === "unknown" ? false : value;
-    }, undefined, { timeout: 30_000, polling: 100 }).then(handle => handle.jsonValue());
-    assert.equal(
-      startupLoadPath,
-      expectCached ? "sqlite-cache" : "fallback-scan",
-      `startup used ${startupLoadPath} instead of the expected ${expectCached ? "SQLite cache" : "fallback scan"}`
-    );
     const indexed = await page.waitForFunction(() => {
       const tape = document.querySelector(".atlas-event-tape");
       const skills = Number(tape?.querySelector("span:nth-child(2) strong")?.textContent?.replace(/,/g, "") || 0);
@@ -91,6 +82,19 @@ const identity = buildIdentity();
         sources
       };
     }, undefined, { timeout: 30_000 }).then(handle => handle.jsonValue());
+
+    // The shell mounts before its asynchronous indexed snapshot completes.
+    // Check the backend diagnostic only after the visible index proves that
+    // load_indexed_snapshot has had a chance to record its actual load path.
+    const startupLoadPath = await page.waitForFunction(async () => {
+      const value = await window.__TAURI_INTERNALS__.invoke("get_startup_load_path");
+      return value === "unknown" ? false : value;
+    }, undefined, { timeout: 30_000, polling: 100 }).then(handle => handle.jsonValue());
+    assert.equal(
+      startupLoadPath,
+      expectCached ? "sqlite-cache" : "fallback-scan",
+      `startup used ${startupLoadPath} instead of the expected ${expectCached ? "SQLite cache" : "fallback scan"}`
+    );
 
     const button = page.locator(".topbar .primary-pill");
     await button.waitFor({ state: "visible" });


### PR DESCRIPTION
## Scope
- Wait for the visible indexed snapshot before asserting the backend startup-path diagnostic.
- Wait briefly for a newly launched isolated process to expose its executable path; refuse to stop a live process whose path cannot be verified.

## Evidence
- Formal release builder contract: 6/6 passed.
- Isolated desktop validation passed with v3.2.1: first-run fallback scan, cached SQLite launch, drag move, restart persistence and restoration.

This changes only formal QA timing and cleanup reliability, not shipped application behavior.